### PR TITLE
Fix wrong class name for stream method in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ an endpoint for the Hystrix Dashboard to monitor.
       response.write('retry: 10000\n');
       response.write('event: connecttime\n');
 
-      hystrixMetrics.stream.pipe(response);
+      HystrixStats.stream.pipe(response);
     };
   }
 ```


### PR DESCRIPTION
This solves a small mistake made in this PR #6 