### PR TITLE
Remove global Transform stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ an endpoint for the Hystrix Dashboard to monitor.
       response.write('retry: 10000\n');
       response.write('event: connecttime\n');
 
-      HystrixStats.stream.pipe(response);
+      hystrixMetrics.getHystrixStream().pipe(response);
     };
   }
 ```

--- a/lib/hystrix-stats.js
+++ b/lib/hystrix-stats.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { Transform, Readable } = require('stream');
+const { Transform } = require('stream');
 const formatter = require('./hystrix-formatter');
 
 /**
@@ -62,13 +62,21 @@ class HystrixStats {
    * @returns {void}
    */
   shutdown () {
-    this._readableStream.unpipe(hystrixStream);
+    this.stream.end();
   }
 }
 
-function _listenForSnapshots(circuit, stream) {
+function _listenForSnapshots (circuit, stream) {
   // Listen for the stats's snapshot event
-  circuit.status.on('snapshot', stats => {
+  const snapshot = stats => {
+    // A little bit of legacy checks to see if we can write.
+    // A better approach would be to maintain a list of all the registered
+    // circuits and remove the listener from each of them.
+    if (stream.destroyed || stream.writableFinished || !stream.writable) {
+      circuit.status.removeListener('snapshot', snapshot);
+      return;
+    }
+
     // when we get a snapshot push it onto the stream
     stream.write(
       Object.assign({},
@@ -78,7 +86,9 @@ function _listenForSnapshots(circuit, stream) {
           group: circuit.group,
           options: circuit.options
         }, stats));
-  });
+  };
+
+  circuit.status.on('snapshot', snapshot);
 }
 
 module.exports = exports = HystrixStats;

--- a/lib/hystrix-stats.js
+++ b/lib/hystrix-stats.js
@@ -3,16 +3,6 @@
 const { Transform, Readable } = require('stream');
 const formatter = require('./hystrix-formatter');
 
-// use a single hystrix stream for all circuits
-const hystrixStream = new Transform({
-  objectMode: true,
-  transform (stats, encoding, cb) {
-    return cb(null, `data: ${JSON.stringify(formatter(stats))}\n\n`);
-  }
-});
-
-hystrixStream.resume();
-
 /**
  * Stream Hystrix Metrics for a given {@link CircuitBreaker}.
  * A HystrixStats instance is created for every {@link CircuitBreaker}
@@ -33,17 +23,19 @@ hystrixStream.resume();
  */
 class HystrixStats {
   constructor (circuits) {
-    this._readableStream = new Readable({
+    // use a single hystrix stream for all circuits
+    this.stream = new Transform({
       objectMode: true,
-      read () {}
+      transform (stats, encoding, cb) {
+        return cb(null, `data: ${JSON.stringify(formatter(stats))}\n\n`);
+      }
     });
 
     circuits.forEach(circuit => {
-      _listenForSnapshots(circuit, this._readableStream);
+      _listenForSnapshots(circuit, this.stream);
     });
 
-    this._readableStream.resume();
-    this._readableStream.pipe(hystrixStream);
+    this.stream.resume();
   }
 
   /**
@@ -52,7 +44,7 @@ class HystrixStats {
    * @returns {void}
    */
   add (circuit) {
-    _listenForSnapshots(circuit, this._readableStream);
+    _listenForSnapshots(circuit, this.stream);
   }
 
   /**
@@ -60,7 +52,7 @@ class HystrixStats {
     @returns {ReadableStream} the statistics stream
   */
   getHystrixStream () {
-    return hystrixStream;
+    return this.stream;
   }
 
   /**
@@ -78,7 +70,7 @@ function _listenForSnapshots(circuit, stream) {
   // Listen for the stats's snapshot event
   circuit.status.on('snapshot', stats => {
     // when we get a snapshot push it onto the stream
-    stream.push(
+    stream.write(
       Object.assign({},
         {
           name: circuit.name,
@@ -86,9 +78,7 @@ function _listenForSnapshots(circuit, stream) {
           group: circuit.group,
           options: circuit.options
         }, stats));
-  });  
+  });
 }
-
-HystrixStats.stream = hystrixStream;
 
 module.exports = exports = HystrixStats;


### PR DESCRIPTION
This removes the global transform stream. From this PR onwards, it would be _only_ accessible through directly from the HystricsMetrix object.

This is a breaking change as it will change the API, considering this is released as 0.0.1, I would recommend to bump to 0.1.0 or 1.0.0.

Fixes #9 